### PR TITLE
Replaced "PSD for Python" to "PSD for Python via .NET" on the Family …

### DIFF
--- a/psd/ar/family/_index.md
+++ b/psd/ar/family/_index.md
@@ -19,7 +19,7 @@ url: family/
 واجهات برمجة تطبيقات Java الأصلية لسطح المكتب أو الويب أو أي نوع من التطبيقات القائمة على Java SE أو EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 واجهة برمجة تطبيقات بايثون عبر .NET لسطح المكتب ويندوز ولينوكس وماك أو إس إيه آر إم.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/cr/family/_index.md
+++ b/psd/cr/family/_index.md
@@ -19,7 +19,7 @@ Cilj Windows Forms, ASP.NET ili bilo koju vrstu aplikacije na temelju .NET Frame
 Izvorni Java API-ji za radnu površinu, web ili bilo koju vrstu aplikacije temeljene na Java SE ili EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 Python API putem .NET za radnu površinu Windows, Linux i macOS i MacOS-arm.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/cz/family/_index.md
+++ b/psd/cz/family/_index.md
@@ -19,7 +19,7 @@ Cíl Windows Forms, ASP.NET nebo jakýkoli typ aplikace založené na rozhraní.
 Nativní rozhraní Java API pro stolní počítače, web nebo jakoukoli aplikaci založenou na jazyce Java SE nebo EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 Python API přes .NET pro stolní počítače Windows, Linux a MacOS a MacOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/de/family/_index.md
+++ b/psd/de/family/_index.md
@@ -19,7 +19,7 @@ Target Windows Forms, ASP.NET oder jede Art von Anwendung, die auf.NET Framework
 Native Java-APIs für den Desktop, das Web oder jede Art von Anwendung, die auf Java SE oder EE basiert.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 Python-API über.NET für den Desktop Windows, Linux und macOS sowie macOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/el/family/_index.md
+++ b/psd/el/family/_index.md
@@ -19,7 +19,7 @@ url: family/
 Εγγενή Java API για την επιφάνεια εργασίας, web ή κάθε είδους εφαρμογή που βασίζεται σε Java SE ή EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 API Python διαμέσω.NET για επιτραπέζιους υπολογιστές Windows, Linux και MacOS και MacOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/en/family/_index.md
+++ b/psd/en/family/_index.md
@@ -19,7 +19,7 @@ Target Windows Forms, ASP.NET or any type of application based on .NET Framework
 Native Java APIs for the desktop, web or any kind of application based on Java SE or EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 Python API via .NET for the desktop Windows, Linux and MacOS and MacOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/es/family/_index.md
+++ b/psd/es/family/_index.md
@@ -19,7 +19,7 @@ Diríjase a Windows Forms, ASP.NET o cualquier tipo de aplicación basada en .NE
 API nativas de Java para escritorio, web o cualquier tipo de aplicación basada en Java SE o EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 API de Python a través de.NET para el escritorio de Windows, Linux y macOS y macOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/fl/family/_index.md
+++ b/psd/fl/family/_index.md
@@ -19,7 +19,7 @@ Windows-muodot, SP. ET tai minkä tahansa tyyppinen sovellus perustuu .ET Framew
 Native Java API työpöydälle, web tai minkäänlaista sovellus perustuu Java SE tai EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 Python-sovellusliittymä.NET: n kautta työpöydälle Windows, Linux ja macOS ja MacOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/fr/family/_index.md
+++ b/psd/fr/family/_index.md
@@ -19,7 +19,7 @@ Ciblez Windows Forms, ASP.NET ou tout type d'application basé sur .NET Framewor
 API Java natives pour le bureau, le Web ou tout type d'application basée sur Java SE ou EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 API Python via .NET pour les ordinateurs de bureau Windows, Linux et macOS et MacOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/hi/family/_index.md
+++ b/psd/hi/family/_index.md
@@ -19,7 +19,7 @@ url: family/
 जावा एसई या ईई पर आधारित डेस्कटॉप, वेब या किसी भी तरह के एप्लिकेशन के लिए नेटिव जावा एपीआई।
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 डेस्कटॉप विंडोज, लिनक्स और मैकओएस और मैकओएस-एआरएम के लिए .NET के माध्यम से पायथन एपीआई।
 {{< /blocks/products/pf/product >}}
 

--- a/psd/id/family/_index.md
+++ b/psd/id/family/_index.md
@@ -19,7 +19,7 @@ Target Windows Forms, ASP.NET atau jenis aplikasi berdasarkan .NET Framework 2.0
 API Java asli untuk desktop, web atau jenis aplikasi berdasarkan Java SE atau EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 Python API melalui .NET untuk desktop Windows, Linux dan macOS dan MacOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/it/family/_index.md
+++ b/psd/it/family/_index.md
@@ -19,7 +19,7 @@ Scegli come target Windows Forms, ASP.NET o qualsiasi tipo di applicazione basat
 API Java native per desktop, web o qualsiasi tipo di applicazione basata su Java SE o EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 API Python via .NET per desktop Windows, Linux e macOS e macOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/jp/family/_index.md
+++ b/psd/jp/family/_index.md
@@ -19,7 +19,7 @@ Windows フォーム、ASP.NET、または.NET Framework 2.0 以降をベース�
 Java SE または EE をベースにしたデスクトップ、Web、またはあらゆる種類のアプリケーション用のネイティブ Java API。
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 デスクトップウィンドウズ、Linux、macOS、MacOS-Arm用の.NET経由のPython API。
 {{< /blocks/products/pf/product >}}
 

--- a/psd/ko/family/_index.md
+++ b/psd/ko/family/_index.md
@@ -19,7 +19,7 @@ Windows Forms, ASP.NET 또는 .NET 프레임워크 2.0 이상을 기반으로 �
 Java SE 또는 EE를 기반으로 하는 데스크톱, 웹 또는 모든 종류의 애플리케이션을 위한 네이티브 Java API입니다.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 데스크톱 윈도우, 리눅스, 맥OS 및 맥OS-ARM용.NET을 통한 파이썬 API.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/pt/family/_index.md
+++ b/psd/pt/family/_index.md
@@ -19,7 +19,7 @@ Destine-se ao Windows Forms, ASP.NET ou qualquer tipo de aplicativo baseado no .
 APIs Java nativas para desktop, web ou qualquer tipo de aplicativo baseado em Java SE ou EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 API Python via .NET para desktop Windows, Linux e macOS e macOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/ru/family/_index.md
+++ b/psd/ru/family/_index.md
@@ -19,7 +19,7 @@ url: family/
 Нативные API-интерфейсы Java для настольных компьютеров, Интернета или любых приложений на основе Java SE или EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 API Python через .NET для настольных компьютеров Windows, Linux, macOS и macOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/sv/family/_index.md
+++ b/psd/sv/family/_index.md
@@ -19,7 +19,7 @@ Mål Windows Forms, ASP.NET eller någon typ av program baserat på .NET Framewo
 Native Java API: er för skrivbordet, webben eller någon form av applikation baserad på Java SE eller EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 Python API via .NET för skrivbordet Windows, Linux och macOS och MacOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/th/family/_index.md
+++ b/psd/th/family/_index.md
@@ -19,7 +19,7 @@ url: family/
 API Java พื้นเมืองสำหรับเดสก์ทอปเว็บหรือชนิดของโปรแกรมใด ๆ บนพื้นฐานของ Java SE หรือ EE
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 Python API ผ่าน .NET สำหรับเดสก์ท็อป Windows, Linux และ macOS และ macOS-ARM
 {{< /blocks/products/pf/product >}}
 

--- a/psd/tr/family/_index.md
+++ b/psd/tr/family/_index.md
@@ -19,7 +19,7 @@ Windows Formlarını, ASP.NET veya .NET Framework 2.0 veya sonraki sürümlerini
 Masaüstü, web veya Java SE veya EE tabanlı her türlü uygulama için yerel Java API'leri.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 Masaüstü Windows, Linux ve macOS ve MacOS-ARM için.NET üzerinden Python API'si.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/ua/family/_index.md
+++ b/psd/ua/family/_index.md
@@ -19,7 +19,7 @@ url: family/
 Рідні API Java для робочого столу, Інтернету або будь-якого виду додатків на основі Java SE або EE.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 API Python через .NET для настільних ПК Windows, Linux та macOS та MacOS-ARM.
 {{< /blocks/products/pf/product >}}
 

--- a/psd/ur/family/_index.md
+++ b/psd/ur/family/_index.md
@@ -19,7 +19,7 @@ url: family/
 ڈیسک ٹاپ، ویب یا جاوا SE یا EE پر مبنی کسی بھی قسم کی درخواست کے لئے مقامی جاوا APIs.
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 ڈیسک ٹاپ ونڈوز، لینکس اور میکوس اور میکوس آرم کیلئے ڈاٹ نیٹ کے ذریعے پایتھن API ۔
 {{< /blocks/products/pf/product >}}
 

--- a/psd/zh/family/_index.md
+++ b/psd/zh/family/_index.md
@@ -19,7 +19,7 @@ url: family/
 用于桌面、Web 或任何基于 Java SE 或 EE 的应用程序的本机 Java API。
 {{< /blocks/products/pf/product >}}
 
-{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
+{{< blocks/products/pf/product pfName="Aspose.PSD for" title="Python via .NET" imgSrc="https://products.aspose.com/psd/images/aspose_psd-for-python-via-net.svg" productLink="python-net/" >}}
 通过 .NET 为桌面 Windows、Linux 和 macOS 以及 macOS-ARM 提供的 Python API。
 {{< /blocks/products/pf/product >}}
 


### PR DESCRIPTION
…page